### PR TITLE
Adapt finder to new src folders in Polylang and Polylang Pro.

### DIFF
--- a/finder.php
+++ b/finder.php
@@ -7,20 +7,10 @@ function sanitize_locale_name(){}
 return \StubsGenerator\Finder::create()
 	->in(
 		[
+			'polylang-pro/src',
 			'polylang-pro/dependencies',
-			'polylang-pro/modules',
-			'polylang-pro/services',
-			'polylang-pro/vendor/wpsyntex/polylang/admin',
-			'polylang-pro/vendor/wpsyntex/polylang/frontend',
-			'polylang-pro/vendor/wpsyntex/polylang/include',
-			'polylang-pro/vendor/wpsyntex/polylang/install',
-			'polylang-pro/vendor/wpsyntex/polylang/modules',
-			'polylang-pro/vendor/wpsyntex/polylang/settings',
+			'polylang-pro/vendor/wpsyntex/polylang/src',
 		]
 	)
-	->append(
-		\StubsGenerator\Finder::create()
-			->in( ['polylang-pro/include'] )
-			->notPath( 'functions.php' )
-	)
+	->notPath( 'polylang-pro/src/functions.php' )
 	->sortByName();

--- a/finder.php
+++ b/finder.php
@@ -12,5 +12,4 @@ return \StubsGenerator\Finder::create()
 			'polylang-pro/vendor/wpsyntex/polylang/src',
 		]
 	)
-	->notPath( 'polylang-pro/src/functions.php' )
 	->sortByName();


### PR DESCRIPTION
## What?
All in the title.
Follows https://github.com/polylang/polylang/pull/1808 and https://github.com/polylang/polylang-pro/pull/2901

Prop: do not remove `polylang-pro/src/functions.php` from stubs.